### PR TITLE
Improved speed for dequeue operation

### DIFF
--- a/lib/Queue/Queue.js
+++ b/lib/Queue/Queue.js
@@ -16,6 +16,13 @@ function Queue(args) {
 	 * @type {Array<*>}
 	 */
 	this.items = [];
+	
+	/**
+	 * Decreases dequeue big O complexity by shifting starting indexs
+	 * for each dequeue, instead of splicing.
+	 * @type {int} 
+	 */
+	this.offsetIndex = 0;
 
     if(args && args.length) {
         //builds the list from the range passed from the constructor
@@ -57,19 +64,48 @@ Queue.prototype.multiEnqueue = function (items) {
  * @return {*} The item at the head of the queue. It's undefined if the queue is empty.
  */
 Queue.prototype.dequeue = function () {
-	if (!this.items.length)
+	if (!(this.items.length - this.offsetIndex))
 		return undefined;
-	return this.items.splice(0, 1)[0]; //remove the first item and return it
+	
+	var dequeued = this.items[this.offsetIndex]; // holds the value, for cases that purge occurs
+	this.offsetIndex++;
+	/**
+	 * Automatically purge unneeded (already dequeued) 
+	 * indexs from the array when they take up 
+	 * more than one half the array
+	 */
+	if (this.offsetIndex >= this.items.length/2){
+		this.purge();
+	}
+
+	return dequeued; //return dequeued item
 };
 
 /**
  * Removes the items at the head of the queue.
  * @param times {number} The number of times to repeat the dequeue method.
  * @return {Array<*>} The items at the head of the queue.
- */
+ */ 
 Queue.prototype.multiDequeue = function (times) {
-	return this.items.splice(0, times); //removes the last times item and returns the array
+	var dequeued = []; // Holds variables that have been removed from the array
+	// Dequeue the desired number of items
+	console.log('items', this.items);
+	for(var i = 0; (i < times && this.items.length -this.offsetIndex > 0); i++){
+		console.log('calleds');
+		dequeued.push(this.dequeue());
+	}
+
+	return dequeued; //removes the last times item and returns the array
 };
+
+/**
+ * Clears array indexs hidden by offset. To free up memory
+ * @return {void}
+ */
+Queue.prototype.purge = function(){
+	this.items.splice(0, this.offsetIndex);
+	this.offsetIndex = 0;
+}
 
 /**
  * Removes the first length items from the position index.
@@ -88,7 +124,9 @@ Queue.prototype.remove = function (index, length) {
  * @return {*} The item at the position. It's undefined if index isn't in the queue bounds.
  */
 Queue.prototype.getItem = function (index) {
-	if (index < 0 || index > this.items.length - 1)
+	// take offsetIndex into account
+	var index = index + this.offsetIndex; 
+	if (index < 0 || index > this.items.length - 1 - this.offsetIndex)
 		return undefined;
 	return this.items[index];
 };
@@ -98,8 +136,8 @@ Queue.prototype.getItem = function (index) {
  * @return {*} The first item. It's undefined if the queue is empty.
  */
 Queue.prototype.peek = function () {
-	if (this.items.length)
-		return this.items[0];
+	if (this.items.length - this.offsetIndex)
+		return this.items[this.offsetIndex];
 	return undefined
 };
 
@@ -121,7 +159,7 @@ Queue.prototype.contains = function (item, callback) {
 	callback = callback || function (it) {
 		return it === item;
 	};
-	var i = 0;
+	var i = this.offsetIndex;
 	while (i < this.items.length && !callback(this.items[i]))
 		i++;
 	return i < this.items.length;
@@ -134,7 +172,7 @@ Queue.prototype.contains = function (item, callback) {
  * @return {void}
  */
 Queue.prototype.execute = function (callback) {
-	for (var i = 0; i < this.items.length; i++)
+	for (var i = this.offsetIndex; i < this.items.length; i++)
 		this.items[i] = callback(this.items[i]);
 };
 
@@ -143,7 +181,7 @@ Queue.prototype.execute = function (callback) {
  * @return {number} The length of the queue.
  */
 Queue.prototype.getLength = function () {
-	return this.items.length;
+	return this.items.length - this.offsetIndex;
 };
 
 /**
@@ -151,7 +189,7 @@ Queue.prototype.getLength = function () {
  * @return {boolean} True if the queue is empty, false otherwise.
  */
 Queue.prototype.isEmpty = function () {
-	return !this.items.length;
+	return !(this.items.length - this.offsetIndex);
 };
 
 /**
@@ -161,7 +199,7 @@ Queue.prototype.isEmpty = function () {
  */
 Queue.prototype.filter = function (callback) {
 	var result = [];
-	for (var i = 0; i < this.items.length; i++)
+	for (var i = this.offsetIndex; i < this.items.length; i++)
 		if (callback(this.items[i]))
 			result.push(this.items[i]);
 	return result;
@@ -177,10 +215,10 @@ Queue.prototype.indexOf = function (item, callback) {
 	callback = callback || function (it) {
 		return it === item;
 	};
-	var i = 0;
+	var i = this.offsetIndex;
 	while (i < this.items.length) {
 		if (callback(this.items[i]))
-			return i;
+			return i - this.offsetIndex;
 		i++;
 	}
 	return -1;
@@ -197,9 +235,10 @@ Queue.prototype.lastIndexOf = function (item, callback) {
 		return it === item;
 	};
 	var i = this.items.length - 1;
-	while (i > -1) {
+	while (i > this.offsetIndex - 1) {
+		console.log('l', this.offsetIndex);
 		if (callback(this.items[i]))
-			return i;
+			return i - this.offsetIndex;
 		i--;
 	}
 	return -1;
@@ -215,11 +254,11 @@ Queue.prototype.allIndexesOf = function (item, callback) {
 	callback = callback || function (it) {
 		return it === item;
 	};
-	var i = 0;
+	var i = this.offsetIndex;
 	var indexes = [];
 	while (i < this.items.length) {
 		if (callback(this.items[i]))
-			indexes.push(i);
+			indexes.push(i - this.offsetIndex);
 		i++;
 	}
 	return indexes;
@@ -231,7 +270,7 @@ Queue.prototype.allIndexesOf = function (item, callback) {
  */
 Queue.prototype.clone = function () {
 	var queue = new Queue();
-	for (var i = 0; i < this.items.length; i++)
+	for (var i = this.offsetIndex; i < this.items.length; i++)
 		if (this.items[i].clone)
 			queue.enqueue(this.items[i].clone());
 		else
@@ -246,7 +285,7 @@ Queue.prototype.clone = function () {
  */
 Queue.prototype.cloneDistinct = function () {
 	var queue = new Queue();
-	for (var i = 0; i < this.items.length; i++)
+	for (var i = this.offsetIndex; i < this.items.length; i++)
 		if (!queue.contains(this.items[i]))
 			if (this.items[i].cloneDistinct)
 				queue.enqueue(this.items[i].cloneDistinct());


### PR DESCRIPTION
This pull request implements an offset that decreases the big O notation of dequeue from O(n) to O(1) (except on purges witch only occur when half of the items array is no longer in the queue). This does increase the amount of memory that is needed. 
